### PR TITLE
(demo) Fork vs unforked environments

### DIFF
--- a/lib/ace/executor.rb
+++ b/lib/ace/executor.rb
@@ -6,9 +6,54 @@ module ACE
       @environment = environment
     end
 
+    # This global env is for demo purposes, hence rubocop disables
+    # ie. when we don't fork, it persists with our get_demo_env method
+    # when we fork, it does not persist
+    $demo_env # rubocop:disable Lint/Void, Style/GlobalVars
+
+    def get_demo_env(arguments)
+      $demo_env ||= arguments['demo_env'] # rubocop:disable Style/GlobalVars
+    end
+
+    def build_response(env)
+      [200, {
+        node: 'some_node_id',
+        status: 'success',
+        result: {
+          output: "Running from demo environment #{env}"
+        }
+      }]
+    end
+
+    def demo_fork(arguments, _options = {})
+      if arguments['fork'] && arguments['fork'].casecmp('true').zero?
+        reader, writer = IO.pipe
+        require 'puppet'
+        pid = fork {
+          reader.close
+          env = get_demo_env(arguments)
+          response = build_response(env)
+          writer.puts JSON.generate(response)
+        }
+        unless pid
+          log "Could not fork"
+          exit 1
+        end
+        writer.close
+        output = reader.read
+        JSON.parse(output)
+      else
+        env = get_demo_env(arguments)
+        build_response(env)
+      end
+    end
+
     def run_task(connection_info, task, arguments, _options = {})
       if connection_info[:'remote-transport'] == 'panos' &&
          task.files.first['filename'] == 'echo.sh'
+        if arguments['sleep']
+          sleep(arguments['sleep'].to_i)
+        end
         [200, {
           node: 'some_node_id',
           status: 'success',

--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -61,5 +61,19 @@ module ACE
 
       [result.first, result.last.to_json]
     end
+
+    post '/demo_fork' do
+      content_type :json
+
+      body = JSON.parse(request.body.read)
+
+      parameters = body['parameters'] || {}
+
+      result = @executor.demo_fork(parameters)
+
+      puts result
+
+      [result.first, result.last.to_json]
+    end
   end
 end


### PR DESCRIPTION
Demo to test forking vs non-forking. After testing 'unforked' restart Puma to ensure environment is cleared down.

```
POST http://0.0.0.0:44633/demo_fork

POST data:
{
  "parameters": {
    "fork": "false",
    "demo_env": "test2"
  }
}
```

With fork = true or false
demo_env as different environments.

When forked false, the first environment executed will persist.
When forked true, environments will be picked up per execution (ensure restarted fresh after a forked=false session)