### PR TITLE
(FM-7872) adding in the acls for the ace service

### DIFF
--- a/config/transport_tasks_config.rb
+++ b/config/transport_tasks_config.rb
@@ -8,6 +8,7 @@
 
 require 'ace/transport_app'
 require 'ace/config'
+require 'bolt_server/acl'
 require 'bolt/logger'
 
 Bolt::Logger.initialize_logging
@@ -40,8 +41,8 @@ bind bind_addr
 threads 0, config['concurrency']
 
 impl = ACE::TransportApp.new(config)
-# unless config.whitelist.nil?
-#   impl = ACE::ACL.new(impl, config.whitelist)
-# end
+unless config['whitelist'].nil?
+  impl = BoltServer::ACL.new(impl, config['whitelist'])
+end
 
 app impl


### PR DESCRIPTION
Part of the PE installation testing is verifying that the ACE service is restricted to the whitelisted addresses.

Without the ACL then these tests would fail and the service would be reachable from outside of the PE infrastructure.

Statement/Question: We could alternatively reuse the BoltServer::ACL class?