### PR TITLE
WIP (maint) Passthrough endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/config/local.conf
+++ b/config/local.conf
@@ -1,7 +1,7 @@
 ace-server: {
-    ssl-cert: "spec/volumes/puppet/ssl/certs/puppet.pem"
-    ssl-key: "spec/volumes/puppet/ssl/private_keys/puppet.pem"
-    ssl-ca-cert: "spec/volumes/puppet/ssl/certs/ca.pem"
+    ssl-cert: "spec/fixtures/ssl/cert.pem"
+    ssl-key: "spec/fixtures/ssl/key.pem"
+    ssl-ca-cert: "spec/fixtures/ssl/ca.pem"
     file-server-uri: "https://0.0.0.0:8140"
     cache-dir: "tmp/"
     loglevel: "debug"


### PR DESCRIPTION
This may be useful for testing purposes.
WIP as need to figure out how to unit test with mocked config


Sample test:

POST to `https://0.0.0.0:44633/passthrough`

```
{
	"passthrough": {
		"method": "post",
		"uri": "https://0.0.0.0:44633/execute_catalog",
		"params": {
			"target": {
				"remote-transport": "panos",
				"host": "fw.example.net",
				"user": "foo",
				"password": "wibble"
			},
			"compiler": {
				"certname": "fail.example.net",
				"environment": "development",
				"transaction_uuid": "42",
				"job_id": "43"
			}
		}
	}
}
```

Returns the valid test response:

```
{"_error":{"msg":"catalog compile failed","kind":"puppetlabs/ace/compile_failed","details":"upstream api errors go here"}}
```