### PR TITLE
(FM-7882) Add client for catalog retrieval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,3 +90,8 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Enabled: false
+
+# see: https://github.com/rubocop-hq/rubocop/issues/4222
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"

--- a/config/docker.conf
+++ b/config/docker.conf
@@ -3,7 +3,7 @@ ace-server: {
     ssl-key: "spec/volumes/puppet/ssl/private_keys/aceserver.pem"
     ssl-ca-cert: "spec/volumes/puppet/ssl/certs/ca.pem"
     ssl-ca-crls: "spec/volumes/puppet/ssl/certs/crl.pem"
-    file-server-uri: "https://spec_puppet_1:8140"
+    puppet-server-uri: "https://spec_puppet_1:8140"
     loglevel: debug
     host: "0.0.0.0"
 }

--- a/config/local.conf
+++ b/config/local.conf
@@ -3,7 +3,7 @@ ace-server: {
     ssl-key: "spec/volumes/puppet/ssl/private_keys/aceserver.pem"
     ssl-ca-cert: "spec/volumes/puppet/ssl/certs/ca.pem"
     ssl-ca-crls: "spec/volumes/puppet/ssl/ca/ca_crl.pem"
-    file-server-uri: "https://0.0.0.0:8140"
+    puppet-server-uri: "https://0.0.0.0:8140"
     cache-dir: "tmp/"
     loglevel: "debug"
 }

--- a/config/transport_tasks_config.rb
+++ b/config/transport_tasks_config.rb
@@ -18,6 +18,7 @@ config_path = ENV['ACE_CONF'] || '/etc/puppetlabs/ace-server/conf.d/ace-server.c
 config = ACE::Config.new
 config.load_file_config(config_path)
 config.load_env_config
+config.make_compatible
 config.validate
 
 Logging.logger[:root].add_appenders Logging.appenders.stderr(

--- a/lib/ace/client/catalog.rb
+++ b/lib/ace/client/catalog.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'ace/error'
+
+module ACE
+  module Client
+    class Catalog
+      def initialize(config)
+        unless config.is_a? ACE::Config
+          raise ACE::Error.new('`config` must be an ACE::Config',
+                               'puppetlabs/ace/invalid_param')
+        end
+        @config = config
+      end
+
+      def retrieve(certname, environment, facts, trusted, transaction_uuid, job_id)
+        raise ACE::Error.new('`facts` must be a Hash', 'puppetlabs/ace/invalid_param') unless facts.is_a? Hash
+        raise ACE::Error.new('`trusted` must be a Hash', 'puppetlabs/ace/invalid_param') unless trusted.is_a? Hash
+
+        uri = URI::HTTP.build(path: '/puppet/v4/catalog')
+
+        input_data = {
+          "certname": certname,
+          "persistence": {
+            "facts": true, "catalog": true
+          },
+          "environment": environment,
+          "facts": {
+            "values": facts
+          },
+          "trusted_facts": {
+            "values": trusted
+          },
+          "transaction_uuid": transaction_uuid,
+          "job_id": job_id,
+          "options": {
+            "prefer_requested_environment": true,
+            "capture_logs": false
+          }
+        }
+
+        header = { 'Content-Type': 'text/json' }
+        request = Net::HTTP::Post.new(uri.request_uri, header)
+        request.body = input_data.to_json
+
+        begin
+          res = client.request(request)
+        rescue StandardError => e
+          raise ACE::Error.new(e.message,
+                               'puppetlabs/ace/client_exception',
+                               class: e.class, backtrace: e.backtrace)
+        end
+        unless res.is_a?(Net::HTTPSuccess)
+          raise ACE::Error.new(res.message,
+                               'puppetlabs/ace/client_failure',
+                               body: res.body)
+        end
+        res
+      end
+
+      private
+
+      def client
+        @client ||= begin
+                        uri = URI(@config['puppet-server-uri'])
+                        Net::HTTP.start(uri.host, uri.port,
+                                        use_ssl: true,
+                                        ssl_version: :TLSv1_2,
+                                        ca_file: @config['ssl-ca-cert'],
+                                        cert: OpenSSL::X509::Certificate.new(ssl_cert),
+                                        key: OpenSSL::PKey::RSA.new(ssl_key),
+                                        verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                        open_timeout: @config['puppet-server-conn-timeout'])
+                      end
+      end
+
+      def ssl_cert
+        @ssl_cert ||= File.read(@config['ssl-cert'])
+      end
+
+      def ssl_key
+        @ssl_key ||= File.read(@config['ssl-key'])
+      end
+    end
+  end
+end

--- a/lib/ace/config.rb
+++ b/lib/ace/config.rb
@@ -7,11 +7,11 @@ module ACE
   class Config < BoltServer::BaseConfig
     attr_reader :data
     def config_keys
-      super + %w[concurrency cache-dir file-server-conn-timeout file-server-uri ssl-ca-crls]
+      super + %w[concurrency cache-dir puppet-server-conn-timeout puppet-server-uri ssl-ca-crls]
     end
 
     def env_keys
-      super + %w[concurrency file-server-conn-timeout file-server-uri ssl-ca-crls]
+      super + %w[concurrency puppet-server-conn-timeout puppet-server-uri ssl-ca-crls]
     end
 
     def ssl_keys
@@ -19,7 +19,7 @@ module ACE
     end
 
     def int_keys
-      %w[concurrency file-server-conn-timeout]
+      %w[concurrency puppet-server-conn-timeout]
     end
 
     def defaults
@@ -27,12 +27,13 @@ module ACE
         'port' => 44633,
         'concurrency' => 10,
         'cache-dir' => "/opt/puppetlabs/server/data/ace-server/cache",
+        'puppet-server-conn-timeout' => 120,
         'file-server-conn-timeout' => 120
       )
     end
 
     def required_keys
-      super + %w[file-server-uri cache-dir]
+      super + %w[puppet-server-uri cache-dir]
     end
 
     def service_name
@@ -58,9 +59,15 @@ module ACE
         raise Bolt::ValidationError, "Configured 'concurrency' must be a positive integer"
       end
 
-      unless natural?(@data['file-server-conn-timeout'])
-        raise Bolt::ValidationError, "Configured 'file-server-conn-timeout' must be a positive integer"
+      unless natural?(@data['puppet-server-conn-timeout'])
+        raise Bolt::ValidationError, "Configured 'puppet-server-conn-timeout' must be a positive integer"
       end
+    end
+
+    def make_compatible
+      # This function sets values used by Bolt that behave the same in ACE, but have a different meaning
+      @data['file-server-uri'] = @data['puppet-server-uri']
+      @data['file-server-conn-timeout'] = @data['puppet-server-conn-timeout']
     end
   end
 end

--- a/lib/ace/plugin_cache.rb
+++ b/lib/ace/plugin_cache.rb
@@ -10,7 +10,7 @@ module ACE
     attr_reader :config, :cache_dir_mutex, :uri
     def initialize(config)
       @config = config
-      @uri = URI.parse(config['file-server-uri'])
+      @uri = URI.parse(config['puppet-server-uri'])
       @cache_dir_mutex = Concurrent::ReadWriteLock.new
     end
 

--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -64,7 +64,17 @@ module ACE
     post '/run_task' do
       content_type :json
 
-      body = JSON.parse(request.body.read)
+      begin
+        body = JSON.parse(request.body.read)
+      rescue StandardError => e
+        request_error = {
+          _error: ACE::Error.new(e.message,
+                                 'puppetlabs/ace/request_exception',
+                                 class: e.class, backtrace: e.backtrace)
+        }
+        return [400, request_error.to_json]
+      end
+
       error = validate_schema(@schemas["run_task"], body)
       return [400, error.to_json] unless error.nil?
 

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -3,7 +3,10 @@
 # to relevant environments for testing
 FROM puppet/puppetserver
 
+COPY ./fixtures/conf/auth.conf /etc/puppetlabs/puppetserver/conf.d/
+
 RUN puppet module install puppetlabs-panos --environment production && \
     puppet module install puppetlabs-cisco_ios --environment production
 
 RUN sed -i "s@# allow-subject-alt-names: false@allow-subject-alt-names: true@" /etc/puppetlabs/puppetserver/conf.d/ca.conf
+

--- a/spec/fixtures/api_server_configs/global-ace-server.conf
+++ b/spec/fixtures/api_server_configs/global-ace-server.conf
@@ -8,7 +8,7 @@ ace-server: {
     ssl-cipher-suites: [a]
 
 
-    file-server-uri: "https://localhost:8140"
+    puppet-server-uri: "https://localhost:8140"
     loglevel: debug
     logfile: /var/log/global
     whitelist: [a]

--- a/spec/fixtures/api_server_configs/required-ace-server.conf
+++ b/spec/fixtures/api_server_configs/required-ace-server.conf
@@ -3,5 +3,5 @@ ace-server: {
     ssl-key: "spec/fixtures/ssl/key.pem"
     ssl-ca-cert: "spec/fixtures/ssl/ca.pem"
     ssl-ca-crls: "spec/fixtures/ssl/crl.pem"
-    file-server-uri: "https://localhost:8140"
+    puppet-server-uri: "https://localhost:8140"
 }

--- a/spec/fixtures/conf/auth.conf
+++ b/spec/fixtures/conf/auth.conf
@@ -1,0 +1,233 @@
+authorization: {
+    version: 1
+    rules: [
+        {
+            # Allow nodes to retrieve their own catalog
+            match-request: {
+                path: "^/puppet/v3/catalog/([^/]+)$"
+                type: regex
+                method: [get, post]
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs v3 catalog from agents"
+        },
+        {
+            # Allow services to retrieve catalogs on behalf of others
+            match-request: {
+                path: "^/puppet/v4/catalog/?$"
+                type: regex
+                method: post
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs v4 catalog for services"
+        },
+        {
+            # Allow nodes to retrieve the certificate they requested earlier
+            match-request: {
+                path: "/puppet-ca/v1/certificate/"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
+        },
+        {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
+            match-request: {
+                path: "/puppet-ca/v1/certificate_request"
+                type: path
+                method: [get, put]
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            # Allow the CA CLI to access the certificate_status endpoint
+            match-request: {
+                path: "/puppet-ca/v1/certificate_status"
+                type: path
+                method: [get, put, delete]
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs cert status"
+        },
+        {
+            # Allow the CA CLI to access the certificate_statuses endpoint
+            match-request: {
+                path: "/puppet-ca/v1/certificate_statuses"
+                type: path
+                method: get
+            }
+            allow: {
+               extensions: {
+                   pp_cli_auth: "true"
+               }
+            }
+            sort-order: 500
+            name: "puppetlabs cert statuses"
+        },
+        {
+            # Allow unauthenticated access to the status service endpoint
+            match-request: {
+                path: "/status/v1/services"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - full"
+        },
+        {
+            match-request: {
+                path: "/status/v1/simple"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status service - simple"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file_bucket_files.  Note that access for
+            # the 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_bucket_file"
+                type: path
+                method: [get, head, post, put]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file bucket file"
+        },
+        {
+            # Allow nodes to access all file_content.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_content"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file content"
+        },
+        {
+            # Allow nodes to access all file_metadata.  Note that access for the
+            # 'delete' method is forbidden by Puppet regardless of the
+            # configuration of this rule.
+            match-request: {
+                path: "/puppet/v3/file_metadata"
+                type: path
+                method: [get, post]
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file metadata"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            # Allow nodes to update their own facts
+            match-request: {
+                path: "^/puppet/v3/facts/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs facts"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/tasks"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppet tasks information"
+        },
+        {
+            # Deny everything else. This ACL is not strictly
+            # necessary, but illustrates the default policy
+            match-request: {
+                path: "/"
+                type: path
+            }
+            deny: "*"
+            sort-order: 999
+            name: "puppetlabs deny all"
+        }
+    ]
+}

--- a/spec/unit/ace/client/catalog_spec.rb
+++ b/spec/unit/ace/client/catalog_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'webmock/rspec'
+require 'ace/client/catalog'
+require 'ace/config'
+
+RSpec.describe ACE::Client::Catalog do
+  describe '#new' do
+    context 'when a valid config is passed' do
+      let(:config) { ACE::Config.new({}) }
+
+      it { expect { described_class.new(config) }.not_to raise_error }
+    end
+
+    context 'when an invalid config is passed' do
+      let(:config) { {} }
+
+      it { expect { described_class.new(config) }.to raise_error ACE::Error, /`config` must be an ACE::Config/ }
+    end
+  end
+
+  def stub_catalog_request(**options)
+    stub_request(:post, 'https://foo:1234/puppet/v4/catalog')
+      .to_return(options)
+  end
+
+  describe '#retrieve' do
+    let(:config) { ACE::Config.new(config_data) }
+    let(:instance) { described_class.new(config) }
+    let(:config_data) do
+      {
+        'ssl-cert' => 'spec/fixtures/ssl/cert.pem',
+        'ssl-key' => 'spec/fixtures/ssl/key.pem',
+        'ssl-ca-cert' => 'spec/fixtures/ssl/ca.pem',
+        'ssl-ca-crls' => 'spec/fixtures/ssl/crl.pem',
+        'puppet-server-uri' => 'https://foo:1234'
+      }
+    end
+    let(:request) do
+      {
+        certname: 'foo.example.com',
+        environment: 'development',
+        facts: {},
+        trusted: {},
+        transaction_uuid: '<transaction_id>',
+        job_id: '<job_id>'
+      }
+    end
+    let(:request_body) do
+      {
+        "certname": 'foo.example.com',
+        "persistence": {
+          "facts": true, "catalog": true
+        },
+        "environment": 'development',
+        "facts": {
+          "values": {}
+        },
+        "trusted_facts": {
+          "values": {}
+        },
+        "transaction_uuid": '<transaction_id>',
+        "job_id": '<job_id>',
+        "options": {
+          "prefer_requested_environment": true,
+          "capture_logs": false
+        }
+      }
+    end
+
+    it 'config should be valid' do
+      expect { config.validate }.not_to raise_error
+    end
+
+    context 'when a valid request is made' do
+      it 'calls the v4 catalog endpoint' do
+        stub_catalog_request(status: 200, body: "{}")
+
+        instance.retrieve(request[:certname],
+                          request[:environment],
+                          request[:facts],
+                          request[:trusted],
+                          request[:transaction_uuid],
+                          request[:job_id])
+
+        expect(a_request(:post, 'https://foo:1234/puppet/v4/catalog')
+              .with(body: request_body.to_json)).to have_been_made.once
+      end
+    end
+
+    context 'when a request is not a success' do
+      let(:error_body) { "{ error: 'wibble' }" }
+
+      it 'throws an ACE::Error with the response body' do
+        stub_catalog_request(status: 500, body: error_body)
+
+        expect {
+          instance.retrieve(request[:certname],
+                            request[:environment],
+                            request[:facts],
+                            request[:trusted],
+                            request[:transaction_uuid],
+                            request[:job_id])
+        }.to raise_error { |error|
+          expect(error).to be_a ACE::Error
+          expect(error.kind).to eq 'puppetlabs/ace/client_failure'
+          expect(error.details).to eq(body: error_body)
+        }
+
+        expect(a_request(:post, 'https://foo:1234/puppet/v4/catalog')
+              .with(body: request_body.to_json)).to have_been_made.once
+      end
+    end
+
+    context 'when the HTTP request throws an exception' do
+      it 'catches and throw an ACE::Error' do
+        allow(Net::HTTP).to receive(:start).and_raise(Errno::ETIMEDOUT, 'Failed to open TCP connection to foo:1234')
+
+        expect {
+          instance.retrieve(request[:certname],
+                            request[:environment],
+                            request[:facts],
+                            request[:trusted],
+                            request[:transaction_uuid],
+                            request[:job_id])
+        }.to raise_error { |error|
+          expect(error).to be_a ACE::Error
+          expect(error.kind).to eq 'puppetlabs/ace/client_exception'
+        }
+      end
+    end
+  end
+end

--- a/spec/unit/ace/plugin_cache_spec.rb
+++ b/spec/unit/ace/plugin_cache_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ACE::PluginCache do
       "ssl-key" => "spec/fixtures/ssl/key.pem",
       "ssl-ca-cert" => "spec/fixtures/ssl/ca.pem",
       "ssl-ca-crls" => "spec/fixtures/ssl/crl.pem",
-      "file-server-uri" => "https://localhost:9999",
+      "puppet-server-uri" => "https://localhost:9999",
       "cache-dir" => "/tmp/environments"
     }
   end

--- a/spec/unit/ace/transport_app_spec.rb
+++ b/spec/unit/ace/transport_app_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe ACE::TransportApp do
       expect(last_response.status).to eq(400)
     end
 
+    it 'throws an ace/request_exception if the request is invalid JSON' do
+      post '/run_task', '{ foo }', 'CONTENT_TYPE' => 'text/json'
+
+      expect(last_response.body).to match(%r{puppetlabs\/ace\/request_exception})
+      expect(last_response.status).to eq(400)
+    end
+
     context 'when the task executes cleanly' do
       it 'runs returns the output' do
         post '/run_task', JSON.generate(body), 'CONTENT_TYPE' => 'text/json'

--- a/spec/unit/ace/transport_app_spec.rb
+++ b/spec/unit/ace/transport_app_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ACE::TransportApp do
     it 'throws an ace/schema_error if the request is invalid' do
       post '/run_task', JSON.generate({}), 'CONTENT_TYPE' => 'text/json'
 
-      expect(last_response.body).to match(%r{ace\/schema-error})
+      expect(last_response.body).to match(%r{puppetlabs\/ace\/schema-error})
       expect(last_response.status).to eq(400)
     end
 
@@ -254,6 +254,15 @@ RSpec.describe ACE::TransportApp do
         result = JSON.parse(last_response.body)
         expect(result).to include('_error')
         expect(result['_error']['msg']).to eq('catalog compile failed')
+      end
+    end
+
+    describe 'bad request' do
+      it 'throws an ace/request_exception if the request is invalid JSON' do
+        post '/execute_catalog', '{ foo }', 'CONTENT_TYPE' => 'text/json'
+
+        expect(last_response.body).to match(%r{puppetlabs\/ace\/request_exception})
+        expect(last_response.status).to eq(400)
       end
     end
 


### PR DESCRIPTION
Example of what would be passed to the endpoint at https://0.0.0.0:44633/execute_catalog

```json
{
  "target":{
    "remote-transport":"panos",
    "host":"bt642as8dm1z0fo.delivery.puppetlabs.net",
    "user":"admin",
    "password":"admin"
  },
  "compiler":{
    "certname":"bt642as8dm1z0fo.delivery.puppetlabs.net",
    "environment":"production",
    "transaction_uuid":"981687ce-520e-11e9-8647-d663bd873d93",
    "job_id":"1"
  }
}
```