### PR TITLE
(maint) additional admin endpoints from bolt-server

### DIFF
--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -60,6 +60,19 @@ module ACE
       [200, 'OK']
     end
 
+    # :nocov:
+    if ENV['RACK_ENV'] == 'dev'
+      get '/admin/gc' do
+        GC.start
+        200
+      end
+    end
+
+    get '/admin/gc_stat' do
+      [200, GC.stat.to_json]
+    end
+    # :nocov:
+
     # run this with "curl -X POST http://0.0.0.0:44633/run_task -d '{}'"
     post '/run_task' do
       content_type :json

--- a/spec/unit/ace/transport_app_spec.rb
+++ b/spec/unit/ace/transport_app_spec.rb
@@ -81,10 +81,12 @@ RSpec.describe ACE::TransportApp do
     allow(plugins).to receive(:setup).and_return(plugins)
   end
 
-  it 'responds ok' do
-    get '/'
-    expect(last_response).to be_ok
-    expect(last_response.status).to eq(200)
+  describe '/' do
+    it 'responds ok' do
+      get '/'
+      expect(last_response).to be_ok
+      expect(last_response.status).to eq(200)
+    end
   end
 
   ################


### PR DESCRIPTION
To keep the debug endpoints the same across products, this adds a few
from bolt-server.