### PR TITLE
(FM-7922) running the configuration to apply catalog to transport

### DIFF
--- a/lib/ace/plugin_cache.rb
+++ b/lib/ace/plugin_cache.rb
@@ -19,15 +19,18 @@ module ACE
       self
     end
 
-    def with_synced_libdir(environment, &block)
+    def with_synced_libdir(environment, certname, &block)
       ForkUtil.isolate do
-        with_synced_libdir_core(environment, &block)
+        with_synced_libdir_core(environment, certname, &block)
       end
     end
 
-    def with_synced_libdir_core(environment)
+    def with_synced_libdir_core(environment, certname)
       libdir = sync_core(environment)
       Puppet[:libdir] = libdir
+      Puppet[:certname] = certname
+      Puppet[:environment] = environment
+      $LOAD_PATH << libdir
       yield
     ensure
       FileUtils.remove_dir(libdir)
@@ -59,8 +62,8 @@ module ACE
       Puppet::Util::Log.newdestination(:console)
       Puppet.settings[:log_level] = 'notice'
       Puppet.settings[:trace] = true
-      Puppet.settings[:catalog_terminus] = :rest
-      Puppet.settings[:node_terminus] = :rest
+      Puppet.settings[:catalog_terminus] = :certless
+      Puppet.settings[:node_terminus] = :plain
       Puppet.settings[:catalog_cache_terminus] = :json
       Puppet.settings[:facts_terminus] = :network_device
     end

--- a/lib/puppet/indirector/catalog/certless.rb
+++ b/lib/puppet/indirector/catalog/certless.rb
@@ -1,0 +1,75 @@
+require 'puppet/resource/catalog'
+require 'puppet/indirector/rest'
+
+class Puppet::Resource::Catalog::Certless < Puppet::Indirector::REST
+  desc "Find certless catalogs over HTTP via REST."
+
+  # Override the REST indirector headers for the certless
+  # catalog indirector as the `puppet/pson` header throws of the
+  # request body and wraps it in a "value":{<request>} which
+  # causes a validation error on the v4/catalog endpoint
+  def headers
+    common_headers = {
+      "Content-Type"                               => 'text/json',
+      "Accept"                                     => 'application/json',
+      Puppet::Network::HTTP::HEADER_PUPPET_VERSION => Puppet.version
+    }
+
+    add_accept_encoding(common_headers)
+  end
+
+  def find(request)
+    uri = "/puppet/v4/catalog"
+
+    body = {
+      "certname": request.key,
+      "persistence": {
+        "facts": true, "catalog": true
+      },
+      "environment": request.environment.name.to_s,
+      "facts": {
+        "values": request.options[:facts]
+      },
+      "trusted_facts": {
+        "values": request.options[:trusted_facts]
+      },
+      "transaction_uuid": request.options[:transaction_uuid],
+      "job_id": request.options[:job_id],
+      "options": {
+        "prefer_requested_environment": true,
+        "capture_logs": false
+      }
+    }
+
+    response = do_request(request) do |req|
+      http_post(req, uri, body.to_json, headers)
+    end
+
+    if is_http_200?(response)
+      content_type, body = parse_response(response)
+      # the response from the `v4/catalog` endpoint is in the format of
+      # {"catalog": {}} whereas the configurer expects it to be a
+      # flatter structurer, so passing it the catalog contents from the body
+      # is suited as the API is unlikely to change for
+      # this release
+      result = deserialize_find(content_type, JSON.parse(body)['catalog'].to_json)
+      result.name = request.key if result.respond_to?(:name=)
+      result
+
+    elsif is_http_404?(response)
+      return nil unless request.options[:fail_on_404]
+
+      # 404 can get special treatment as the indirector API can not produce a meaningful
+      # reason to why something is not found - it may not be the thing the user is
+      # expecting to find that is missing, but something else (like the environment).
+      # While this way of handling the issue is not perfect, there is at least an error
+      # that makes a user aware of the reason for the failure.
+      #
+      _, body = parse_response(response)
+      msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(uri_with_query_string, 100), body: body }
+      raise Puppet::Error, msg
+    else
+      nil
+    end
+  end
+end

--- a/spec/acceptance/transport_app_spec.rb
+++ b/spec/acceptance/transport_app_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ace/transport_app'
+require 'rack/test'
+require 'ace/config'
+
+RSpec.describe ACE::TransportApp do
+  include Rack::Test::Methods
+
+  def app
+    ACE::TransportApp.new(ACE::Config.new(base_config))
+  end
+
+  let(:base_config) do
+    {
+      "ssl-cert" => "spec/volumes/puppet/ssl/certs/aceserver.pem",
+      "ssl-key" => "spec/volumes/puppet/ssl/private_keys/aceserver.pem",
+      "ssl-ca-cert" => "spec/volumes/puppet/ssl/certs/ca.pem",
+      "ssl-ca-crls" => "spec/volumes/puppet/ssl/ca/ca_crl.pem",
+      "puppet-server-uri" => "https://localhost:8140",
+      "cache-dir" => "tmp/"
+    }
+  end
+  
+  let(:execute_catalog_body) do
+    {
+      "target": {
+        "remote-transport": "panos",
+        host: certname,
+        user: "admin",
+        password: "admin",
+        ssl: false
+      },
+      "compiler": {
+        "certname": certname,
+        "environment": "production",
+        "transaction_uuid": Random.new_seed.to_s,
+        "job_id": Random.new_seed.to_s
+      }
+    }
+  end
+
+  ##################
+  # Catalog Endpoint
+  ##################
+  describe '/execute_catalog' do
+
+    describe 'success' do
+      let(:certname) { 'vvtzckq3vzx995w.delivery.puppetlabs.net' }
+
+      it 'returns 200 with empty body when success' do
+        post '/execute_catalog', JSON.generate(execute_catalog_body), 'CONTENT_TYPE' => 'text/json'
+        expect(last_response.errors).to match(/\A\Z/)
+        expect(last_response).to be_ok
+        expect(last_response.status).to eq(200)
+        result = JSON.parse(last_response.body)
+        expect(result).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Largily the code here will not work on its own, as there are outstanding PRs for the `init_puppet_target` and the `trusted_facts` that are required.

There is also some changes to the configurer in Puppet that have been made locally, that will be discussed later/groomed.

This is mainly to raise discussions - we still need to sort out the environment isolation and split out the Puppet setup code from the `plugins` as it might be best to have a puppet settings class that isolates the puppet settings and then calls the pluginsync, and then the configurer - but again this is best to discuss as a team and this PR is not trying to refactor the existing code.