### PR TITLE
(maint) remove load_config parameter

### DIFF
--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -19,7 +19,7 @@ module ACE
   class TransportApp < Sinatra::Base
     def initialize(config = nil)
       @config = config
-      @executor = Bolt::Executor.new(0, load_config: false)
+      @executor = Bolt::Executor.new(0)
       tasks_cache_dir = File.join(@config['cache-dir'], 'tasks')
       @file_cache = BoltServer::FileCache.new(@config.data.merge('cache-dir' => tasks_cache_dir)).setup
       environments_cache_dir = File.join(@config['cache-dir'], 'environments')

--- a/spec/unit/ace/transport_app_spec.rb
+++ b/spec/unit/ace/transport_app_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe ACE::TransportApp do
   end
 
   before do
-    allow(Bolt::Executor).to receive(:new).and_return(executor)
+    allow(Bolt::Executor).to receive(:new).with(0).and_return(executor)
     allow(BoltServer::FileCache).to receive(:new).and_return(file_cache)
     allow(ACE::PluginCache).to receive(:new).and_return(plugins)
     allow(file_cache).to receive(:setup)


### PR DESCRIPTION
Changes introduced in Bolt https://github.com/puppetlabs/bolt/commit/77690441e1f5655b824dfc653b07cbf5beb9861f caused this to break. 
In flight system test will prevent this from going unnoticed.
