### PR TITLE
(maint) fixing up the docker setup for executing catalogs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install gems
-FROM alpine:3.8 as build
+FROM puppet/puppet-agent-alpine:6.4.2 as build
 
 RUN \
 apk --no-cache add build-base ruby-dev ruby-bundler ruby-json ruby-bigdecimal git openssl-dev && \
@@ -12,11 +12,6 @@ ADD . /ace
 WORKDIR /ace
 RUN rm Gemfile.lock
 RUN bundle install --no-cache --path vendor/bundle
-
-# symlink the usr local ruby to the one expected
-# in a task
-RUN mkdir -p /opt/puppetlabs/puppet/bin/ && \
-    ln -s /usr/bin/ruby /opt/puppetlabs/puppet/bin/ruby
 
 # Final image
 FROM build

--- a/config/docker.conf
+++ b/config/docker.conf
@@ -1,9 +1,18 @@
 ace-server: {
-    ssl-cert: "spec/volumes/puppet/ssl/certs/aceserver.pem"
-    ssl-key: "spec/volumes/puppet/ssl/private_keys/aceserver.pem"
-    ssl-ca-cert: "spec/volumes/puppet/ssl/certs/ca.pem"
-    ssl-ca-crls: "spec/volumes/puppet/ssl/certs/crl.pem"
-    puppet-server-uri: "https://spec_puppet_1:8140"
+    # being explicit about the pathing within the container
+    # although it is ran from within the /ace directory
+    # we feel it is best to distinguish that this is a
+    # docker configuration file and not a `local`
+    ssl-cert: "/ace/spec/volumes/puppet/ssl/certs/aceserver.pem"
+    ssl-key: "/ace/spec/volumes/puppet/ssl/private_keys/aceserver.pem"
+    ssl-ca-cert: "/ace/spec/volumes/puppet/ssl/certs/ca.pem"
+    ssl-ca-crls: "/ace/spec/volumes/puppet/ssl/ca/ca_crl.pem"
+    # the dns of puppet within  the docker network
+    # is the same as spec_puppet_1 locally as the
+    # hostname is `puppet` within the docker network
+    puppet-server-uri: "https://puppet:8140"
     loglevel: debug
+    # host to run the ACE service on, i.e.
+    # 0.0.0.0 within the container
     host: "0.0.0.0"
 }

--- a/developer-docs/docker.md
+++ b/developer-docs/docker.md
@@ -42,7 +42,7 @@ sudo chmod a+rx -R volumes/
 
 At this point it is required to generate certs for the `aceserver`, this can be achieved though:
 
-`docker exec spec_puppet_1 puppetserver ca generate --certname aceserver --subject-alt-names localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0,puppet`
+`docker exec spec_puppet_1 puppetserver ca generate --certname aceserver --subject-alt-names localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0,puppet,spec_puppet_1,ace_aceserver_1`
 
 On Linux, ensure that you have access to the newly created files:
 
@@ -51,6 +51,15 @@ sudo chmod a+rx -R volumes/
 ```
 
 Reasoning for this is that it makes it easier to ensure that the cert names are consistent across environments.
+
+_Note_: If the `aceserver` certificate needs regenerated the following steps can be performed:
+
+```
+docker exec spec_puppet_1 puppetserver ca revoke --certname aceserver
+docker exec spec_puppet_1 rm /etc/puppetlabs/puppet/ssl/certs/aceserver.pem /etc/puppetlabs/puppet/ssl/private_keys/aceserver.pem /etc/puppetlabs/puppet/ssl/public_keys/aceserver.pem /etc/puppetlabs/puppet/ssl/ca/signed/aceserver.pem
+```
+
+And then generate the certificate again using the `ca generate` command from above.
 
 ## Verifying the services
 


### PR DESCRIPTION
Since the execution of catalogs requires Puppet configuration, the original base image did not have the required dependencies and initialisation was failing.

This change extends the puppet-agent alpine image and runs the ACE service on top in order to ensure the relevant dependencies are met.

Part of this change also required updating of the certificate requirements for working both within a container and `locally`, which means existing container users will need to regenerate new certs and restart the puppetserver,

```
cd spec/
docker-compose up -d --build --force-recreate
```

Instructions on regenerating the cert has been added to the docker.md file in developer-docs.