### PR TITLE
(maint) using the CA_ALLOW_SUBJECT_ALT_NAMES env variable for new doc…

### DIFF
--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -8,6 +8,3 @@ COPY ./fixtures/conf/auth.conf /etc/puppetlabs/puppetserver/conf.d/
 RUN puppet module install puppetlabs-panos --environment production && \
     puppet module install puppetlabs-cisco_ios --environment production && \
     puppet module install puppetlabs-test_device --environment production
-
-RUN sed -i "s@# allow-subject-alt-names: false@allow-subject-alt-names: true@" /etc/puppetlabs/puppetserver/conf.d/ca.conf
-

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - DNS_ALT_NAMES=puppet,localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0
       - PUPPETDB_SERVER_URLS=https://puppetdb:8081
+      - CA_ALLOW_SUBJECT_ALT_NAMES=true
     volumes:
       - ./volumes/puppet:/etc/puppetlabs/puppet/
       - ./volumes/serverdata:/opt/puppetlabs/server/data/puppetserver/


### PR DESCRIPTION
…ker container

The new images uses hocon to add the allow sans based on env variable, so setting this variable means no longer is there a need for sed.