### PR TITLE
(PE-27024) return detailed results from `/execute_catalog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ACE is built-in to PE as pe-ace-server.
 
 ## Development
 
-As ACE is dependent on Puppet Server, there is a docker-compose file in the `spec/` directory which we advise you run before  the ACE service to ensure that the certs and keys are valid. For more information, see the [docker documentation](developer-docs/docker.md).
+As ACE is dependent on Puppet Server, there is a docker-compose file in the `spec/` directory which we advise you run before the ACE service to ensure that the certs and keys are valid. For more information, see the [docker documentation](developer-docs/docker.md).
 
 To release a new version, update the version number in `version.rb`, generate a new changelog with `bundle exec rake changelog`, commit the results and run `bundle exec rake release`, which creates a git tag for the version, pushes git commits and tags, and pushes the `.gem` file to [rubygems.org](https://rubygems.org). Released gems are eventually consumed by [ace-vanagon](https://github.com/puppetlabs/ace-vanagon) and promoted into PE.
 

--- a/developer-docs/docker.md
+++ b/developer-docs/docker.md
@@ -31,7 +31,9 @@ sudo chmod a+rx -R volumes/
 
 At this point it is required to generate certs for the `aceserver`, this can be achieved though:
 
-`docker exec spec_puppet_1 puppetserver ca generate --certname aceserver --subject-alt-names localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0,puppet,spec_puppet_1,ace_aceserver_1`
+```
+docker exec spec_puppet_1 puppetserver ca generate --certname aceserver --subject-alt-names localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0,puppet,spec_puppet_1,ace_aceserver_1
+```
 
 On Linux, ensure that you have access to the newly created files:
 

--- a/spec/acceptance/ace/transport_app_spec.rb
+++ b/spec/acceptance/ace/transport_app_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe ACE::TransportApp do
     end
 
     describe 'success' do
-      it 'returns 200 with `report_generated` status' do
+      it 'returns 200 with `unchanged` status' do
         post '/execute_catalog', JSON.generate(execute_catalog_body), 'CONTENT_TYPE' => 'text/json'
         expect(last_response.errors).to match(/\A\Z/)
         expect(last_response).to be_ok
         expect(last_response.status).to eq(200)
         result = JSON.parse(last_response.body)
         expect(result['certname']).to eq('localhost')
-        expect(result['status']).to eq('report_generated')
+        expect(result['status']).to eq('unchanged')
       end
     end
   end


### PR DESCRIPTION
To facilitate a responsive UX, `/execute_catalog` should return the same status codes as https://github.com/puppetlabs/pxp-agent/blob/918eaed001d8a2098053ce344e8bb9381be4fe8e/modules/pxp-module-puppet#L204-L210
    
This change implements that by extracting the report from the `run` method and reformatting the results as required.
