### PR TITLE
(QENG-7501) Minor formatting change to push tag in build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## App Overview
 
-The Agentless Catalog Executor (ACE) provides agentless executions services for tasks and catalogs to Puppet Enterprise (PE). See [developer-docs/api](developer-docs/api.md) for an API spec. See below for development info.
+The Agentless Catalog Executor (ACE) provides agentless executions services for tasks and catalogs to Puppet Enterprise (PE). See [developer-docs/api](developer-docs/api.md) for an API spec. 
+
+See below for development info.
 
 ## Code Overview
 


### PR DESCRIPTION
A minor formatting change to `README.md` to generate an arbitrary change and push the `v1.0.0` tag through the CI pipeline. See [QENG-7501](https://tickets.puppetlabs.com/browse/QENG-7501) for more details.