### PR TITLE
(PE-27794) add a puma status endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,11 +37,14 @@ Style/NumericPredicate:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 Layout/ClosingHeredocIndentation:
   Enabled: false
+
+Layout/LineLength:
+  Max: 120
 
 Style/GuardClause:
   Enabled: false
@@ -71,9 +74,6 @@ Metrics/ClassLength:
 
 Metrics/CyclomaticComplexity:
   Enabled: false
-
-Metrics/LineLength:
-  Max: 120
 
 Metrics/MethodLength:
   Enabled: false

--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -198,6 +198,11 @@ module ACE
     get '/admin/gc_stat' do
       [200, GC.stat.to_json]
     end
+
+    get '/admin/status' do
+      stats = Puma.stats
+      [200, stats.is_a?(Hash) ? stats.to_json : stats]
+    end
     # :nocov:
 
     # run this with "curl -X POST http://0.0.0.0:44633/run_task -d '{}'"


### PR DESCRIPTION
With this commit, a puma status endpoint is added to our app.
(We already implement the gc_stats endpoint.)

Since this endpoint is served by our app, there will always be one
thread in use in the result: that thread is the status request itself.

This is not true with the default puma status endpoint,
as it runs within a separate server ... as per puma/lib/puma/runner.rb.