### PR TITLE
(maint) Update Task constructor to follow new pattern in Bolt

### DIFF
--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -265,7 +265,8 @@ module ACE
 
         target.first.inventory = inventory
 
-        task = Bolt::Task::PuppetServer.new(body['task'], @file_cache)
+        task_data = body['task']
+        task = Bolt::Task::PuppetServer.new(task_data['name'], task_data['metadata'], task_data['files'], @file_cache)
 
         parameters = body['parameters'] || {}
 


### PR DESCRIPTION
The Task struct in bolt was refactored to be a proper class. Part of the refactor was changing the init method. This commit updates task instantiation to be compatible with the refactored class in Bolt. https://github.com/puppetlabs/bolt/commit/308405933786ed2c1becd9ea978fa67c76cf5dde#