### PR TITLE
(PE-29007) Update to bolt > 2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ before_install:
   - docker network create spec_default
   - docker-compose -f ./spec/docker-compose.yml up -d --build
   - docker ps -a
-  - while true; do echo Checking...; echo $(docker logs spec_puppet_1 --tail 10) | grep -q 'Puppet Server has successfully started' && break; sleep 1; done ;
+  - i="0"; while true; do echo Checking...; echo $(docker logs spec_puppet_1 --tail 10) | grep -q 'Puppet Server has successfully started' && break; if [ $i -gt 90 ]; then exit 1; fi; sleep 1; i=$[$i+1]; done;
   - docker exec spec_puppet_1 puppetserver ca generate --certname aceserver --subject-alt-names 'puppet,localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0'

--- a/agentless-catalog-executor.gemspec
+++ b/agentless-catalog-executor.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # Pin concurrent-ruby to 1.1.5 until https://github.com/ruby-concurrency/concurrent-ruby/pull/856 is released
   spec.add_dependency "concurrent-ruby", "1.1.5"
 
-  spec.add_dependency "bolt",  "~> 2.0"
+  spec.add_dependency "bolt",  "~> 2.9"
 
   # server-side dependencies cargo culted from https://github.com/puppetlabs/bolt/blob/4418da408643aa7eb5ed64f4c9704b941ea878dc/Gemfile#L10-L16
   spec.add_dependency "hocon", ">= 1.2.5"

--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -137,11 +137,11 @@ module ACE
     end
 
     def scrub_stack_trace(result)
-      if result.dig(:value, '_error', 'details', 'stack_trace')
-        result[:value]['_error']['details'].reject! { |k| k == 'stack_trace' }
+      if result.dig('value', '_error', 'details', 'stack_trace')
+        result['value']['_error']['details'].reject! { |k| k == 'stack_trace' }
       end
-      if result.dig(:value, '_error', 'details', 'backtrace')
-        result[:value]['_error']['details'].reject! { |k| k == 'backtrace' }
+      if result.dig('value', '_error', 'details', 'backtrace')
+        result['value']['_error']['details'].reject! { |k| k == 'backtrace' }
       end
       result
     end
@@ -254,13 +254,13 @@ module ACE
         result = ForkUtil.isolate do
           # Since this will only be on one node we can just return the first result
           results = @executor.run_task(target, task, parameters)
-          scrub_stack_trace(results.first.status_hash)
+          scrub_stack_trace(results.first.to_data)
         end
         [200, result.to_json]
       rescue Exception => e # rubocop:disable Lint/RescueException
         # handle all the things and make it obvious what happened
         process_error = {
-          "target": target.name,
+          "target": target.first.name,
           "action": nil,
           "object": nil,
           "status": "failure",

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,7 +1,7 @@
 # used for the puppetserver in order
 # for some modules to be installed and
 # to relevant environments for testing
-FROM puppet/puppetserver
+FROM puppet/puppetserver:edge
 
 COPY ./fixtures/conf/auth.conf /etc/puppetlabs/puppetserver/conf.d/
 COPY ./fixtures/conf/enc.sh /usr/local/bin/enc.sh

--- a/spec/unit/ace/transport_app_spec.rb
+++ b/spec/unit/ace/transport_app_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ACE::TransportApp do
       ).and_return(task_response)
 
       allow(task_response).to receive(:first).and_return(response)
-      allow(response).to receive(:status_hash).and_return(status)
+      allow(response).to receive(:to_data).and_return(status)
     end
 
     it 'throws an ace/schema_error if the request is invalid' do


### PR DESCRIPTION
This commit updates ace-server to reflect changes to the bolt `Result` object. This also fixes a bug in error creation whereby previously the `Target` we attempt to reference `name` for will always be the only element in an array, the `name` method was attempted to be called on the `Array`, this has been updated to call the method on the `Target`.