### PR TITLE
(PE-30044) Remove harmful terminology from ace

### DIFF
--- a/config/transport_tasks_config.rb
+++ b/config/transport_tasks_config.rb
@@ -42,8 +42,8 @@ bind bind_addr
 threads 0, config['concurrency']
 
 impl = ACE::TransportApp.new(config)
-unless config['whitelist'].nil?
-  impl = BoltServer::ACL.new(impl, config['whitelist'])
+unless config['allowlist'].nil?
+  impl = BoltServer::ACL.new(impl, config['allowlist'])
 end
 
 app impl

--- a/spec/fixtures/api_server_configs/global-ace-server.conf
+++ b/spec/fixtures/api_server_configs/global-ace-server.conf
@@ -11,6 +11,6 @@ ace-server: {
     puppet-server-uri: "https://localhost:8140"
     loglevel: debug
     logfile: /var/log/global
-    whitelist: [a]
+    allowlist: [a]
     concurrency: 12
 }

--- a/spec/unit/ace/config_spec.rb
+++ b/spec/unit/ace/config_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ACE::Config do
 
   let(:complete_config_keys) {
     ['host', 'port', 'ssl-cert', 'ssl-key', 'ssl-ca-cert',
-     'ssl-cipher-suites', 'loglevel', 'logfile', 'whitelist',
+     'ssl-cipher-suites', 'loglevel', 'logfile', 'allowlist', 'projects-dir',
      'concurrency', 'cache-dir', 'puppet-server-conn-timeout',
      'puppet-server-uri', 'ssl-ca-crls'].freeze
   }
@@ -40,7 +40,7 @@ RSpec.describe ACE::Config do
 
   let(:complete_defaults) {
     { 'host' => '127.0.0.1',
-      'loglevel' => 'notice',
+      'loglevel' => 'warn',
       'ssl-cipher-suites' => ['ECDHE-ECDSA-AES256-GCM-SHA384',
                               'ECDHE-RSA-AES256-GCM-SHA384',
                               'ECDHE-ECDSA-CHACHA20-POLY1305',


### PR DESCRIPTION
This commit removes the `whitelist` references in ace-server and
replaces them with `allowlist`. This is part of the effort to remove
harmful terminology, and will configure ace to use the new `allowlist`
ace-server.conf key rather than the old key.