### PR TITLE
(PE-31081) Open ended bolt dep

### DIFF
--- a/agentless-catalog-executor.gemspec
+++ b/agentless-catalog-executor.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # Pin concurrent-ruby to 1.1.5 until https://github.com/ruby-concurrency/concurrent-ruby/pull/856 is released
   spec.add_dependency "concurrent-ruby", "1.1.5"
 
-  spec.add_dependency "bolt",  ">= 2.9", "< 4.0"
+  spec.add_dependency "bolt",  ">= 2.9"
 
   # server-side dependencies cargo culted from https://github.com/puppetlabs/bolt/blob/4418da408643aa7eb5ed64f4c9704b941ea878dc/Gemfile#L10-L16
   spec.add_dependency "hocon", ">= 1.2.5"


### PR DESCRIPTION
Given we control exactly what version of bolt is shipped with PE, leave the gemspec unbounded at the upper end to avoid pain around `x` bumps in the future.