### PR TITLE
(PE-31688) Remove unused, deprecated pattern

### DIFF
--- a/lib/ace/plugin_cache.rb
+++ b/lib/ace/plugin_cache.rb
@@ -49,17 +49,12 @@ module ACE
     end
 
     def with_synced_libdir_core(environment)
-      pool = Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout])
-      Puppet.push_context({
-                            http_pool: pool
-                          }, "Isolated HTTP Pool")
       libdir = sync_core(environment)
       Puppet.settings[:libdir] = libdir
       $LOAD_PATH << libdir
       yield
     ensure
       FileUtils.remove_dir(libdir)
-      pool.close
     end
 
     # the Puppet[:libdir] will point to a tmp location

--- a/spec/unit/ace/plugin_cache_spec.rb
+++ b/spec/unit/ace/plugin_cache_spec.rb
@@ -86,10 +86,6 @@ RSpec.describe ACE::PluginCache do
                                            URI.parse('https://localhost:9999'))
       FileUtils.mkdir_p('/tmp/environment_cache/production')
       ACE::PuppetUtil.isolated_puppet_settings('foo', 'production', false, '/tmp/environment_cache/production')
-      pool = Puppet::Network::HTTP::NoCachePool.new
-      Puppet.push_context({
-                            http_pool: pool
-                          }, "Isolated HTTP Pool")
     end
     # This example is a ugly tradeoff between more confidence in calling the
     # Puppet::Configurer::PluginHandler.new.download_plugins methods and having


### PR DESCRIPTION
Previously we were configuing an http pool for pluginsync. The internal puppet client now handles this and pushing our own instance onto puppet's context is no longer needed.