### PR TITLE
(PE-31686) use new v4 catalog endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,6 @@ group :development do
   gem 'rubocop-rspec'
 end
 
+gem 'puppet', git: 'https://github.com/puppetlabs/puppet.git', branch: '6.x'
 # Specify your gem's dependencies in agentless-catalog-executor.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,5 @@ group :development do
   gem 'rubocop-rspec'
 end
 
-gem 'puppet', git: 'https://github.com/puppetlabs/puppet.git', branch: '6.x'
 # Specify your gem's dependencies in agentless-catalog-executor.gemspec
 gemspec

--- a/agentless-catalog-executor.gemspec
+++ b/agentless-catalog-executor.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hocon", ">= 1.2.5"
   spec.add_dependency "json-schema", ">= 2.8.0"
   spec.add_dependency "puma", ">= 3.12.0"
-  spec.add_dependency "puppet", "~> 6.18"
+  spec.add_dependency "puppet", "~> 6.23"
   spec.add_dependency "rack", ">= 2.0.5"
   spec.add_dependency "rails-auth", ">= 2.1.4"
   spec.add_dependency "sinatra", ">= 2.0.4"

--- a/lib/puppet/indirector/catalog/certless.rb
+++ b/lib/puppet/indirector/catalog/certless.rb
@@ -9,72 +9,33 @@ module Puppet
       class Certless < Puppet::Indirector::REST
         desc "Find certless catalogs over HTTP via REST."
 
-        # Override the REST indirector headers for the certless
-        # catalog indirector as the `puppet/pson` header throws of the
-        # request body and wraps it in a "value":{<request>} which
-        # causes a validation error on the v4/catalog endpoint
-        def headers
-          common_headers = {
-            "Content-Type" => 'text/json',
-            "Accept" => 'application/json',
-            Puppet::Network::HTTP::HEADER_PUPPET_VERSION => Puppet.version
-          }
-
-          add_accept_encoding(common_headers)
-        end
-
         def find(request)
-          uri = "/puppet/v4/catalog"
-
-          body = {
-            "certname": request.key,
-            "persistence": {
-              "facts": true, "catalog": true
-            },
-            "environment": request.environment.name.to_s,
-            "facts": {
-              "values": request.options[:transport_facts]
-            },
-            "trusted_facts": {
-              "values": request.options[:trusted_facts]
-            },
-            "transaction_uuid": request.options[:transaction_uuid],
-            "job_id": request.options[:job_id],
-            "options": {
-              "prefer_requested_environment": false,
-              "capture_logs": false
+          certname = request.key
+          payload = {
+            persistence: { facts: true, catalog: true },
+            environment: request.environment.name.to_s,
+            facts: request.options[:transport_facts],
+            trusted_facts: request.options[:trusted_facts],
+            transaction_uuid: request.options[:transaction_uuid],
+            job_id: request.options[:job_id],
+            options: {
+              prefer_requested_environment: false,
+              capture_logs: false
             }
           }
-
-          response = do_request(request) do |req|
-            http_post(req, uri, body.to_json, headers)
-          end
-
-          if is_http_200?(response)
-            content_type, body = parse_response(response)
-            # the response from the `v4/catalog` endpoint is in the format of
-            # {"catalog": {}} whereas the configurer expects it to be a
-            # flatter structurer, so passing it the catalog contents from the body
-            # is suited as the API is unlikely to change for
-            # this release
-            result = deserialize_find(content_type, JSON.parse(body)['catalog'].to_json)
-            result.name = request.key if result.respond_to?(:name=)
-            result
-
-          elsif is_http_404?(response)
+          session = Puppet.lookup(:http_session)
+          api = session.route_to(:puppet)
+          _, catalog, = api.post_catalog4(certname, payload)
+          catalog
+        rescue Puppet::HTTP::ResponseError => e
+          if e.response.code == 404
             return nil unless request.options[:fail_on_404]
 
-            # 404 can get special treatment as the indirector API can not produce a meaningful
-            # reason to why something is not found - it may not be the thing the user is
-            # expecting to find that is missing, but something else (like the environment).
-            # While this way of handling the issue is not perfect, there is at least an error
-            # that makes a user aware of the reason for the failure.
-            #
-            _, body = parse_response(response)
-            msg = format(_("Find %<uri>s resulted in 404 with the message: %<body>s"),
-                         uri: elide(uri, 100),
-                         body: body)
+            _, body = parse_response(e.response)
+            msg = "Find resulted in 404 with the message: #{body}"
             raise Puppet::Error, msg
+          else
+            raise convert_to_http_error(e.response)
           end
         end
       end

--- a/spec/unit/ace/plugin_cache_spec.rb
+++ b/spec/unit/ace/plugin_cache_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe ACE::PluginCache do
 
   let(:puppetserver_directory_path) { '/foo/' }
   let(:fake_file_path) { 'fake_file.rb' }
-  let(:params) { '?checksum_type=md5&environment=production&ignore=.hg&links=follow&recurse=true&source_permissions=' }
+  let(:params) {
+    '?checksum_type=md5&environment=production&ignore=.hg&links=follow&max_files=-1&recurse=true&source_permissions='
+  }
 
   before do
     allow(ACE::ForkUtil).to receive(:isolate).and_yield


### PR DESCRIPTION
In a related body of work [1], a new method was added to the
Puppet::HTTP::Service::Compiler class to expose the v4 catalog
endpoint in puppetserver. This commit changes the catalog indirector
to use that new method to find certless catalogs.

[1]: https://github.com/puppetlabs/puppet/commit/c3800ff0b17fa56728f14e0e928aa7e64f535a1b