### PR TITLE
(maint) remove concurrent-ruby lock

### DIFF
--- a/agentless-catalog-executor.gemspec
+++ b/agentless-catalog-executor.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = "~> 2.5"
-  # Pin concurrent-ruby to 1.1.5 until https://github.com/ruby-concurrency/concurrent-ruby/pull/856 is released
-  spec.add_dependency "concurrent-ruby", "1.1.5"
 
   spec.add_dependency "bolt",  ">= 2.9"
 


### PR DESCRIPTION
concurrent-ruby was locked to 1.1.5 in https://github.com/puppetlabs/ace/pull/69
due to an issue in 1.1.6. A fix for that was released
in concurrent-ruby-1.1.7: https://github.com/ruby-concurrency/concurrent-ruby/pull/856

Recently, in puppet-runtime, concurrent-ruby was
bumped to 1.1.8 https://github.com/puppetlabs/puppet-runtime/pull/446/files#diff-6393a204a090900f17b88f58f21f2b5c355271b5e8df85328a80accbc2c503e0R2
making ruby pe-ace-server unable to start:

```
-- Unit pe-ace-server.service has begun starting up.
May 17 08:15:28 main-wisdom puma[15711]: /opt/puppetlabs/puppet/lib/ruby/2.5.0/rubygems/dependency.rb:312:in `to_specs’: Could not find ‘concurrent-ruby’ (= 1.1.5) - did find: [concurrent-ruby-1.1.8] (Gem::MissingSpecVersionError)
```

This commit removes the lock of concurrent-ruby as
the upstream issue was fixed and released.