### PR TITLE
(PE-31689) Don't fork in run_task endpoint

### DIFF
--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -251,11 +251,9 @@ module ACE
 
         parameters = body['parameters'] || {}
 
-        result = ForkUtil.isolate do
-          # Since this will only be on one node we can just return the first result
-          results = @executor.run_task(target, task, parameters)
-          scrub_stack_trace(results.first.to_data)
-        end
+        # Since this will only be on one node we can just return the first result
+        results = @executor.run_task(target, task, parameters)
+        result = scrub_stack_trace(results.first.to_data)
         [200, result.to_json]
       rescue Exception => e # rubocop:disable Lint/RescueException
         # handle all the things and make it obvious what happened


### PR DESCRIPTION
This was originally added as part of
https://github.com/puppetlabs/ace/pull/12 with no context behind the
addition. Turns out it is an unnecessary efficiency, so we revert back
to the previous behavior of just calling executor.run_task and having
the request-handling thread run the task. This is OK since the run_task
endpoint only takes in one target.

Signed-off-by: Enis Inan <enis.inan@puppet.com>