### PR TITLE
(PE-31696) Allow puppet 7.x in addition to puppet 6.x in gemspec

### DIFF
--- a/agentless-catalog-executor.gemspec
+++ b/agentless-catalog-executor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hocon", ">= 1.2.5"
   spec.add_dependency "json-schema", ">= 2.8.0"
   spec.add_dependency "puma", ">= 3.12.0"
-  spec.add_dependency "puppet", "~> 6.23"
+  spec.add_dependency "puppet", ">= 6.23", "< 8.0.0"
   spec.add_dependency "rack", ">= 2.0.5"
   spec.add_dependency "rails-auth", ">= 2.1.4"
   spec.add_dependency "sinatra", ">= 2.0.4"

--- a/spec/unit/ace/plugin_cache_spec.rb
+++ b/spec/unit/ace/plugin_cache_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ACE::PluginCache do
   let(:puppetserver_directory_path) { '/foo/' }
   let(:fake_file_path) { 'fake_file.rb' }
   let(:params) {
-    '?checksum_type=md5&environment=production&ignore=.hg&links=follow&max_files=-1&recurse=true&source_permissions='
+    '?checksum_type=sha256&environment=production&ignore=.hg&links=follow&max_files=-1&recurse=true&source_permissions='
   }
 
   before do

--- a/spec/unit/puppet/resource/catalog/certless_spec.rb
+++ b/spec/unit/puppet/resource/catalog/certless_spec.rb
@@ -103,11 +103,10 @@ RSpec.describe Puppet::Resource::Catalog::Certless do
       allow(request).to receive(:options).and_return(request_options)
 
       # need a Net::HTTP response
-      uri = URI.parse('https://www.example.com')
       stub_request(:post, 'https://www.example.com')
         .to_return(status: 404, headers: { "Content-Type" => 'application/json' })
-      net_http_response = Net::HTTP.post(uri, {})
-      puppet_http_response = Puppet::HTTP::Response.new(net_http_response, uri)
+      http_response = Net::HTTP.post(uri, '')
+      puppet_http_response = Puppet::HTTP::ResponseNetHTTP.new(uri, http_response)
 
       allow(compiler).to receive(:post_catalog4).and_raise(Puppet::HTTP::ResponseError.new(puppet_http_response))
 


### PR DESCRIPTION
Ace is now compatible with both streams of puppet library.