### PR TITLE
(PE-31696) Require bolt gem before running local tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
-dist: xenial
+dist: focal
 language: ruby
-cache: bundler
 rvm:
-  - 2.5.1
+  - 2.7
 services:
   - docker
 # Workaround for https://tickets.puppetlabs.com/browse/FM-8106
 install: bundle install --path=.bundle
 before_install:
+  - echo $DOCKER_PW | docker login --username $DOCKER_USER --password-stdin
   - docker network create spec_default
   - docker-compose -f ./spec/docker-compose.yml up -d --build
   - docker ps -a
   - i="0"; while true; do echo Checking...; echo $(docker logs spec_puppet_1 --tail 10) | grep -q 'Puppet Server has successfully started' && break; if [ $i -gt 90 ]; then exit 1; fi; sleep 1; i=$[$i+1]; done;
   - docker exec spec_puppet_1 puppetserver ca generate --certname aceserver --subject-alt-names 'puppet,localhost,aceserver,ace_aceserver_1,spec_puppetserver_1,ace_server,puppet_server,spec_aceserver_1,puppetdb,spec_puppetdb_1,0.0.0.0'
+
+script:
+  - mkdir -p /opt/puppetlabs/puppet/bin/
+  - ln -svf $(bundle exec which ruby) /opt/puppetlabs/puppet/bin/ruby
+  - sudo chmod a+rx -R spec/volumes
+  - bundle exec rake

--- a/agentless-catalog-executor.gemspec
+++ b/agentless-catalog-executor.gemspec
@@ -22,13 +22,13 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.5"
 
-  spec.add_dependency "bolt",  ">= 2.9"
+  spec.add_dependency "bolt",  ">= 3.20"
 
   # server-side dependencies cargo culted from https://github.com/puppetlabs/bolt/blob/4418da408643aa7eb5ed64f4c9704b941ea878dc/Gemfile#L10-L16
   spec.add_dependency "hocon", ">= 1.2.5"
   spec.add_dependency "json-schema", ">= 2.8.0"
   spec.add_dependency "puma", ">= 3.12.0"
-  spec.add_dependency "puppet", "~> 6.23"
+  spec.add_dependency "puppet", ">= 6.23.0", "< 8.0.0"
   spec.add_dependency "rack", ">= 2.0.5"
   spec.add_dependency "rails-auth", ">= 2.1.4"
   spec.add_dependency "sinatra", ">= 2.0.4"

--- a/lib/ace/transport_app.rb
+++ b/lib/ace/transport_app.rb
@@ -221,6 +221,12 @@ module ACE
         validate_schema(@schemas["run_task"], body)
 
         inventory = Bolt::Inventory.empty
+        local_data = { 'name' => 'localhost',
+                       'config' => { 'transport' => 'local',
+                                     'local' => { 'interpreters' => {
+                                       'rb' => ['/opt/puppetlabs/puppet/bin/ruby', '-r', 'bolt']
+                                     } } } }
+        Bolt::Target.from_hash(local_data, inventory)
         target_data = {
           'name' => body['target']['host'] || body['target']['name'] || 'remote',
           'config' => {
@@ -250,9 +256,8 @@ module ACE
         task = Bolt::Task::PuppetServer.new(task_data['name'], task_data['metadata'], task_data['files'], @file_cache)
 
         parameters = body['parameters'] || {}
-
-        # Since this will only be on one node we can just return the first result
         results = @executor.run_task(target, task, parameters)
+        # Since this will only be on one node we can just return the first result
         result = results.first
         # Unwrap _sensitive output (orchestrator will handle obfuscating it from the result)
         if result.value.is_a?(Hash) && result.value.key?('_sensitive')

--- a/spec/unit/ace/plugin_cache_spec.rb
+++ b/spec/unit/ace/plugin_cache_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ACE::PluginCache do
   let(:puppetserver_directory_path) { '/foo/' }
   let(:fake_file_path) { 'fake_file.rb' }
   let(:params) {
-    '?checksum_type=md5&environment=production&ignore=.hg&links=follow&max_files=-1&recurse=true&source_permissions='
+    '?checksum_type=sha256&environment=production&ignore=.hg&links=follow&max_files=-1&recurse=true&source_permissions='
   }
 
   before do

--- a/spec/unit/puppet/resource/catalog/certless_spec.rb
+++ b/spec/unit/puppet/resource/catalog/certless_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe Puppet::Resource::Catalog::Certless do
       uri = URI.parse('https://www.example.com')
       stub_request(:post, 'https://www.example.com')
         .to_return(status: 404, headers: { "Content-Type" => 'application/json' })
-      net_http_response = Net::HTTP.post(uri, {})
-      puppet_http_response = Puppet::HTTP::Response.new(net_http_response, uri)
+      net_http_response = Net::HTTP.post(uri, '')
+      puppet_http_response = Puppet::HTTP::ResponseNetHTTP.new(uri, net_http_response)
 
       allow(compiler).to receive(:post_catalog4).and_raise(Puppet::HTTP::ResponseError.new(puppet_http_response))
 


### PR DESCRIPTION
In PE we use the Ruby interpreter shipped with the Puppet Agent to run the
ace server. The ace server is responsible for executing remote tasks.
Remote tasks will often use the puppet library, and run in ACE using the
local transport. Now that puppet has moved to using require_relative
there is a bug where require 'puppet' in the task will load Puppet
from the Ruby vendor path instead of the Puppet gem. The vendor Puppet
will then try to autoload gems from the Gem path including Puppet,
causing a UniqueFile error when the same file is loaded from different
locations.

This updates ACE to run -r bolt before executing tasks on localhost,
which will add Bolt and it's dependencies to the $LOAD_PATH including
Puppet, so that the Gem puppet is prefered over the vendor Puppet.